### PR TITLE
support multibyte character

### DIFF
--- a/lib/hubdown/page_builder.rb
+++ b/lib/hubdown/page_builder.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require 'hubdown/style_generator'
 require 'erb'
 

--- a/lib/hubdown/template.html.erb
+++ b/lib/hubdown/template.html.erb
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="UTF-8">
   <title><%= filename || ''%></title>
   <% links.each do |link| -%>
     <%= link.to_tag %>


### PR DESCRIPTION
When a source include multibyte character, an output is garbled.
So added meta tag to template.
